### PR TITLE
Add OpenAI compatibility

### DIFF
--- a/src/autocorrect_service.py
+++ b/src/autocorrect_service.py
@@ -248,12 +248,13 @@ class AutocorrectService:
             try:
                 input_tokens = self.count_tokens(prompt)
                 response = requests.post(
-                    url="https://openrouter.ai/api/v1/chat/completions",
+                    url=f"{self.settings.get_setting('api_endpoint', 'https://openrouter.ai/api/v1/chat/completions')}",
                     headers={
-                        "Authorization": f"Bearer {self.settings.get_setting('open_router_key')}",
+                        "Content-Type": "application/json",
+                        "Authorization": f"Bearer {self.settings.get_setting('provider_api_key')}",
                     },
                     data=json.dumps({
-                        "model": "openai/gpt-4o-mini",
+                        "model": f"{self.settings.get_setting('api_model', 'openai/gpt-4o-mini')}",
                         "messages": [{"role": "user", "content": prompt}]
                     }),
                     timeout=10
@@ -267,8 +268,12 @@ class AutocorrectService:
                 completion_text = response_data['choices'][0]['message']['content']
                 completion_tokens = self.count_tokens(completion_text)
 
-                self.settings.update_usage(input_tokens, completion_tokens)
+                default_endpoint = self.settings.get_default_setting('api_endpoint')
+                default_model = self.settings.get_default_setting('api_model')
 
+                if (self.settings.get_setting('api_endpoint') == default_endpoint and
+                        self.settings.get_setting('api_model') == default_model):
+                    self.settings.update_usage(input_tokens, completion_tokens)
 
                 return response_data
             except requests.exceptions.RequestException as e:

--- a/src/settings_manager.py
+++ b/src/settings_manager.py
@@ -39,7 +39,9 @@ class SettingsManager:
         'custom_prompt.use_replacements': True,
         'custom_prompt.auto_custom_prompt': True,
         'auto_select_text': False,
-        'open_router_key': '',
+        'provider_api_key': '',
+        'api_endpoint': 'https://openrouter.ai/api/v1/chat/completions',
+        'api_model': 'openai/gpt-4o-mini',
         'replacements': {
             'i': 'I',
             'jz': 'jetzt',
@@ -427,6 +429,9 @@ class SettingsManager:
     def get_setting(self, key: str, default: Any = None) -> Any:
         return self.settings.get(key, default)
 
+    def get_default_setting(self, key: str, default: Any = None) -> Any:
+        return self.DEFAULT_SETTINGS.get(key, default)
+
     def set_setting(self, key: str, value: Any) -> None:
         self.settings[key] = value
         self.save_settings()
@@ -436,11 +441,11 @@ class SettingsManager:
 
     def reset_settings(self) -> None:
         usage_stats = self.settings.get('usage_stats', self.DEFAULT_SETTINGS['usage_stats']).copy()
-        open_router_key = self.settings.get('open_router_key', self.DEFAULT_SETTINGS['open_router_key'])
+        provider_api_key = self.settings.get('provider_api_key', self.DEFAULT_SETTINGS['provider_api_key'])
 
         self.settings = self.DEFAULT_SETTINGS.copy()
         self.settings['usage_stats'] = usage_stats
-        self.settings['open_router_key'] = open_router_key
+        self.settings['provider_api_key'] = provider_api_key
         self.save_settings()
 
     def update_usage(self, input_tokens: int, completion_tokens: int) -> None:


### PR DESCRIPTION
This pull request adds the functionality to configure the LLM provider endpoint url and model.
This has the advantage that users are not dependent on Openrouter and can use several different providers.
By configuring a custom endpoint or model, the functionality to calculate the usage data correctly is omitted. 

## Changes made

- Added textinput for endpoint url
- Added textinput for model
- deactivated usage and cost statistics if custom endpoint or model are set